### PR TITLE
Explicitly requiring BigDecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2020-04-25
+### Fixed
+- Added explicit `BigDecimal` require.
+
 ## [0.4.0] - 2020-02-16
 ### Added
 - Supporting [Bracket Orders](https://docs.alpaca.markets/trading-on-alpaca/orders/#bracket-orders)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    alpaca-trade-api (0.4.0)
+    alpaca-trade-api (0.4.1)
       faraday (~> 0.15)
 
 GEM
@@ -14,7 +14,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    faraday (0.15.4)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.4.0)
     json (2.2.0)

--- a/lib/alpaca/trade/api.rb
+++ b/lib/alpaca/trade/api.rb
@@ -14,6 +14,7 @@ require 'alpaca/trade/api/position'
 require 'alpaca/trade/api/client'
 require 'alpaca/trade/api/errors'
 
+require 'bigdecimal/util'
 require 'json'
 
 module Alpaca

--- a/lib/alpaca/trade/api/version.rb
+++ b/lib/alpaca/trade/api/version.rb
@@ -3,7 +3,7 @@
 module Alpaca
   module Trade
     module Api
-      VERSION = '0.4.0'
+      VERSION = '0.4.1'
     end
   end
 end


### PR DESCRIPTION
Releasing 0.4.1. Closes #8.