### PR TITLE
Adds fractionable and notional orders

### DIFF
--- a/lib/alpaca/trade/api/asset.rb
+++ b/lib/alpaca/trade/api/asset.rb
@@ -5,7 +5,7 @@ module Alpaca
     module Api
       class Asset
         attr_reader :id, :asset_class, :exchange, :symbol, :status, :tradable, :marginable,
-                    :shortable, :easy_to_borrow
+                    :shortable, :easy_to_borrow, :fractionable
 
         def initialize(json)
           @id = json['id']
@@ -17,6 +17,7 @@ module Alpaca
           @marginable = json['marginable']
           @shortable = json['shortable']
           @easy_to_borrow = json['easy_to_borrow']
+          @fractionable = json['fractionable']
         end
       end
     end

--- a/lib/alpaca/trade/api/client.rb
+++ b/lib/alpaca/trade/api/client.rb
@@ -112,16 +112,17 @@ module Alpaca
           LastTrade.new(JSON.parse(response.body))
         end
 
-        def new_order(symbol:, qty:, side:, type:, time_in_force:, limit_price: nil,
-          stop_price: nil, extended_hours: false, client_order_id: nil, order_class: nil,
-          take_profit: nil, stop_loss: nil)
+        def new_order(symbol:, side:, type:, time_in_force:, qty: nil, notional: nil,
+          limit_price: nil, stop_price: nil, extended_hours: false, client_order_id: nil,
+          order_class: nil, take_profit: nil, stop_loss: nil)
 
           params = {
             symbol: symbol,
-            qty: qty,
             side: side,
             type: type,
             time_in_force: time_in_force,
+            qty: qty,
+            notional: notional,
             limit_price: limit_price,
             order_class: order_class,
             stop_price: stop_price,

--- a/lib/alpaca/trade/api/version.rb
+++ b/lib/alpaca/trade/api/version.rb
@@ -3,7 +3,7 @@
 module Alpaca
   module Trade
     module Api
-      VERSION = '0.7.0'
+      VERSION = '0.8.0'
     end
   end
 end

--- a/spec/alpaca/trade/client_spec.rb
+++ b/spec/alpaca/trade/client_spec.rb
@@ -233,6 +233,27 @@ RSpec.describe Alpaca::Trade::Api::Client do
       order.legs.each { |leg| expect(leg).to be_an(Alpaca::Trade::Api::Order) }
     end
 
+    it 'supports fractionable orders', :vcr do
+        # require 'pry'; binding.pry
+      order = subject.new_order(symbol: 'AAPL',
+                                qty: 1.8,
+                                side: 'buy',
+                                type: 'market',
+                                time_in_force: 'day')
+      expect(order).to be_an(Alpaca::Trade::Api::Order)
+      expect(order.id).to_not be_nil
+    end
+
+    it 'supports notional orders', :vcr do
+      order = subject.new_order(symbol: 'AAPL',
+                                notional: 500,
+                                side: 'buy',
+                                type: 'market',
+                                time_in_force: 'day')
+      expect(order).to be_an(Alpaca::Trade::Api::Order)
+      expect(order.id).to_not be_nil
+    end
+
     it 'raises an exception when buying power is not sufficient', :vcr do
       expect { subject.new_order(symbol: 'AAPL',
                                  qty: 5_000,

--- a/spec/cassettes/Alpaca_Trade_Api_Client/_new_order/supports_fractionable_orders.yml
+++ b/spec/cassettes/Alpaca_Trade_Api_Client/_new_order/supports_fractionable_orders.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://paper-api.alpaca.markets/v2/orders
+    body:
+      encoding: UTF-8
+      string: '{"symbol":"AAPL","qty":1.8,"side":"buy","type":"market","time_in_force":"day","extended_hours":false}'
+    headers:
+      User-Agent:
+      - Faraday v1.4.1
+      Apca-Api-Key-Id:
+      - "<KEY ID>"
+      Apca-Api-Secret-Key:
+      - "<KEY SECRET>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Tue, 20 Apr 2021 19:20:21 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '752'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"id":"<ID>","client_order_id":"6fe20a99-49de-4488-bc5d-8f1620fe57da","created_at":"2021-04-20T19:20:21.423227Z","updated_at":"2021-04-20T19:20:21.423227Z","submitted_at":"2021-04-20T19:20:21.417153Z","filled_at":null,"expired_at":null,"canceled_at":null,"failed_at":null,"replaced_at":null,"replaced_by":null,"replaces":null,"asset_id":"b0b6dd9d-8b9b-48a9-ba46-b9d54906e415","symbol":"AAPL","asset_class":"us_equity","notional":null,"qty":"1.8","filled_qty":"0","filled_avg_price":null,"order_class":"","order_type":"market","type":"market","side":"buy","time_in_force":"day","limit_price":null,"stop_price":null,"status":"accepted","extended_hours":false,"legs":null,"trail_percent":null,"trail_price":null,"hwm":null}'
+    http_version:
+  recorded_at: Tue, 20 Apr 2021 19:20:21 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/Alpaca_Trade_Api_Client/_new_order/supports_notional_orders.yml
+++ b/spec/cassettes/Alpaca_Trade_Api_Client/_new_order/supports_notional_orders.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://paper-api.alpaca.markets/v2/orders
+    body:
+      encoding: UTF-8
+      string: '{"symbol":"AAPL","side":"buy","type":"market","time_in_force":"day","notional":500,"extended_hours":false}'
+    headers:
+      User-Agent:
+      - Faraday v1.4.1
+      Apca-Api-Key-Id:
+      - "<KEY ID>"
+      Apca-Api-Secret-Key:
+      - "<KEY SECRET>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Tue, 20 Apr 2021 19:22:24 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '752'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"id":"<ID>","client_order_id":"12915f93-630b-46ef-9524-89e00d46aa62","created_at":"2021-04-20T19:22:23.997222Z","updated_at":"2021-04-20T19:22:23.997222Z","submitted_at":"2021-04-20T19:22:23.990302Z","filled_at":null,"expired_at":null,"canceled_at":null,"failed_at":null,"replaced_at":null,"replaced_by":null,"replaces":null,"asset_id":"b0b6dd9d-8b9b-48a9-ba46-b9d54906e415","symbol":"AAPL","asset_class":"us_equity","notional":"500","qty":null,"filled_qty":"0","filled_avg_price":null,"order_class":"","order_type":"market","type":"market","side":"buy","time_in_force":"day","limit_price":null,"stop_price":null,"status":"accepted","extended_hours":false,"legs":null,"trail_percent":null,"trail_price":null,"hwm":null}'
+    http_version:
+  recorded_at: Tue, 20 Apr 2021 19:22:24 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
This change adds to the Asset class a boolean field to determine if an asset can be ordered in a fractionable amount. If the asset is fractionable, a new order can be created for that asset using a float as the quantity. Furthermore, the quantity `qty` field for a new order is now optional, however new orders require that either the `qty` or `notional` argument is passed. Notional allows for a set dollar amount of a fractionable asset to be passed to create a new order.