### PR TITLE
Raise 400 responses as an InvalidRequest

### DIFF
--- a/lib/alpaca/trade/api/client.rb
+++ b/lib/alpaca/trade/api/client.rb
@@ -111,7 +111,7 @@ module Alpaca
 
         def last_trade(symbol:)
           response = get_request(data_endpoint, "v1/last/stocks/#{symbol}")
-          raise InvalidRequest, JSON.parse(response.body)['message'] if response.status == 404
+          raise InvalidRequest, JSON.parse(response.body)['message'] if [404, 400].include?(response.status)
 
           LastTrade.new(JSON.parse(response.body))
         end
@@ -138,6 +138,7 @@ module Alpaca
           response = post_request(endpoint, 'v2/orders', params.compact)
           raise InsufficientFunds, JSON.parse(response.body)['message'] if response.status == 403
           raise MissingParameters, JSON.parse(response.body)['message'] if response.status == 422
+          raise InvalidRequest, JSON.parse(response.body)['message'] if response.status == 400
 
           Order.new(JSON.parse(response.body))
         end
@@ -182,7 +183,7 @@ module Alpaca
           response = patch_request(endpoint, "v2/orders/#{id}", params.compact)
           raise InsufficientFunds, JSON.parse(response.body)['message'] if response.status == 403
           raise InvalidOrderId, JSON.parse(response.body)['message'] if response.status == 404
-          raise InvalidRequest, JSON.parse(response.body)['message'] if response.status == 422
+          raise InvalidRequest, JSON.parse(response.body)['message'] if [400, 422].include?(response.status)
 
           Order.new(JSON.parse(response.body))
         end


### PR DESCRIPTION
If there is a malformed request, in my case it was passing an array of strings for the "symbols" parameter, the client will return an Order with all nil parameters, instead of rightfully raising an error when it wasn't fulfilled.

This adds checking for 400 errors in various places within the client and raises an InvalidRequest with the error message.